### PR TITLE
fix: correct Renovate regex patterns for README.md

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
         "/^README\\.md$/"
       ],
       "matchStrings": [
-        "\\| `kairos_version` \\| Kairos version for fallback Dockerfile \\| ❌ \\| `(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)` \\|"
+        "\\| `kairos_version` \\| string \\| no \\| `(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)` \\|"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "kairos-io/kairos",
@@ -66,6 +66,32 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/kairos-io/hadron-trusted",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "base_image: \"ghcr.io/kairos-io/hadron:(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/kairos-io/hadron",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "\\| `base_image` \\| string \\| no \\| `ghcr.io/kairos-io/hadron:(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)` \\|"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/kairos-io/hadron",
       "versioningTemplate": "semver",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }


### PR DESCRIPTION
## Summary

- Fixed the `kairos_version` regex pattern that didn't match the actual README table format (expected "Kairos version for fallback Dockerfile | ❌" but actual format is "string | no")
- Added missing regex patterns for hadron `base_image` references in README.md to keep examples in sync with workflow defaults

This resolves the Renovate dashboard errors for:
- Update kairos_version to v4.0.3
- Update hadron base image to v0.1.1

## Test plan

- [ ] Merge this PR
- [ ] Check the "trigger Renovate" checkbox on the Dependency Dashboard issue
- [ ] Verify Renovate can now successfully create PRs for the errored updates


Made with [Cursor](https://cursor.com)