### PR TITLE
Allow user to prevent failed grype from failing the build

### DIFF
--- a/.github/workflows/reusable-factory.yaml
+++ b/.github/workflows/reusable-factory.yaml
@@ -113,7 +113,7 @@ on:
       grype_sarif_fail_build:
         type: boolean
         default: true
-        description: "Whether the Grype SARIF generation step should fail the build when vulnerabilities at/above the severity cutoff are found. Set to false to leave build gating entirely to security_scan_mode, so SARIF only reports to the GitHub Security tab without failing the build."
+        description: "Whether the Grype SARIF scan step should fail the job when vulnerabilities at/above the severity cutoff are found. Set to false to prevent SARIF generation from failing the job; build gating may still occur via security_scan_mode when grype/trivy scans are enabled."
 
       trivy_sarif:
         type: boolean

--- a/.github/workflows/reusable-factory.yaml
+++ b/.github/workflows/reusable-factory.yaml
@@ -110,6 +110,11 @@ on:
         type: boolean
         default: false
 
+      grype_sarif_fail_build:
+        type: boolean
+        default: true
+        description: "Whether the Grype SARIF generation step should fail the build when vulnerabilities at/above the severity cutoff are found. Set to false to leave build gating entirely to security_scan_mode, so SARIF only reports to the GitHub Security tab without failing the build."
+
       trivy_sarif:
         type: boolean
         default: false
@@ -791,6 +796,7 @@ jobs:
           severity-cutoff: critical
           add-cpes-if-none: true
           only-fixed: true
+          fail-build: ${{ inputs.grype_sarif_fail_build }}
           config: ${{ steps.grype-config.outputs.path }}
 
       - name: Filter Grype SARIF to critical

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ All inputs below come from `.github/workflows/reusable-factory.yaml`.
 | `grype` | boolean | no | `false` | Run Grype scan against built image. |
 | `trivy` | boolean | no | `false` | Run Trivy scan against built image. |
 | `grype_sarif` | boolean | no | `false` | Generate, filter, and upload Grype SARIF report. |
+| `grype_sarif_fail_build` | boolean | no | `true` | Whether the Grype SARIF step fails the build on findings at/above the severity cutoff. Set to `false` to leave build gating to `security_scan_mode` and only report to the Security tab. |
 | `trivy_sarif` | boolean | no | `false` | Generate, filter, and upload Trivy SARIF report. |
 | `registry_domain` | string | no | - | Registry domain used for login/push (example: `ghcr.io`). |
 | `registry_namespace` | string | no | - | Registry namespace/organization. |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ All inputs below come from `.github/workflows/reusable-factory.yaml`.
 | `grype` | boolean | no | `false` | Run Grype scan against built image. |
 | `trivy` | boolean | no | `false` | Run Trivy scan against built image. |
 | `grype_sarif` | boolean | no | `false` | Generate, filter, and upload Grype SARIF report. |
-| `grype_sarif_fail_build` | boolean | no | `true` | Whether the Grype SARIF step fails the build on findings at/above the severity cutoff. Set to `false` to leave build gating to `security_scan_mode` and only report to the Security tab. |
+| `grype_sarif_fail_build` | boolean | no | `true` | Whether the Grype SARIF scan step fails the job on findings at/above the severity cutoff. Set to `false` to prevent SARIF generation from failing the job; the build may still fail due to `security_scan_mode` when `grype`/`trivy` scans are enabled. |
 | `trivy_sarif` | boolean | no | `false` | Generate, filter, and upload Trivy SARIF report. |
 | `registry_domain` | string | no | - | Registry domain used for login/push (example: `ghcr.io`). |
 | `registry_namespace` | string | no | - | Registry namespace/organization. |


### PR DESCRIPTION
Kept default to `true` to avoid breaking it for any consumers expecting it to work this way.