### PR TITLE
feat: add allow_insecure_registries input

### DIFF
--- a/.github/workflows/reusable-factory.yaml
+++ b/.github/workflows/reusable-factory.yaml
@@ -52,6 +52,11 @@ on:
         type: boolean
         default: false
 
+      allow_insecure_registries:
+        type: boolean
+        default: false
+        description: "Allow auroraboot to pull container images from registries over plain HTTP or with untrusted/self-signed TLS certificates when generating artifacts (ISO/UKI/RAW). Useful on self-hosted runners that pull from a local or in-cluster registry (e.g. localhost:5000/...). Passed to auroraboot as --allow-insecure-registries, and as --set allow-insecure-registries=true for the RAW flow."
+
       # Individual artifact types
       iso:
         type: boolean
@@ -910,6 +915,10 @@ jobs:
               DOCKER_CMD="$DOCKER_CMD --output /output/"
             fi
 
+            if [[ "${{ inputs.allow_insecure_registries }}" == "true" ]]; then
+              DOCKER_CMD="$DOCKER_CMD --allow-insecure-registries"
+            fi
+
             if [[ "${{ inputs.trusted_boot }}" == "true" ]]; then
               DOCKER_CMD="$DOCKER_CMD --output-type=iso"
               DOCKER_CMD="$DOCKER_CMD --public-keys /keys"
@@ -982,6 +991,9 @@ jobs:
           DOCKER_CMD="$DOCKER_CMD --set \"container_image=docker:${{ steps.setup.outputs.image_tag }}\""
           DOCKER_CMD="$DOCKER_CMD --set \"state_dir=/output\""
           DOCKER_CMD="$DOCKER_CMD --set \"disk.raw=true\""
+          if [[ "${{ inputs.allow_insecure_registries }}" == "true" ]]; then
+            DOCKER_CMD="$DOCKER_CMD --set \"allow-insecure-registries=true\""
+          fi
 
           echo "🔧 Executing: $DOCKER_CMD"
           eval $DOCKER_CMD


### PR DESCRIPTION
Allows auroraboot to pull images from registries over plain HTTP or with untrusted/self-signed TLS certificates when generating ISO/UKI/RAW artifacts. Targets self-hosted runners pulling from local or in-cluster registries.

Part of https://github.com/kairos-io/kairos/issues/4081