### PR TITLE
feat: add an optional ref input for the checkout step

### DIFF
--- a/.github/workflows/reusable-factory.yaml
+++ b/.github/workflows/reusable-factory.yaml
@@ -9,6 +9,27 @@ on:
         required: false
     inputs:
       # Dockerfile path
+      ref:
+        description: |
+          Git ref or SHA to check out. Defaults to the ref that triggered the
+          calling workflow, which is the right answer for every ordinary caller.
+
+          Set this only when the caller must build something other than its own
+          trigger ref -- the motivating case is a `pull_request_target` workflow
+          that needs to build a fork pull request's head commit, since that
+          event's context is the base branch.
+
+          Only `ref` is exposed, deliberately: a pull request's head commit is
+          reachable from the base repository via `refs/pull/<n>/head`, so no
+          second repository ever needs naming, and omitting `repository` means
+          this cannot be pointed at code outside the calling repo.
+
+          Security note for callers: passing an untrusted ref here in a workflow
+          that also has access to secrets means running that code with those
+          secrets. This input is neutral; the caller carries the risk.
+        type: string
+        required: false
+        default: ''
       dockerfile_path:
         type: string
 
@@ -277,6 +298,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: '0'
+          # Empty is actions/checkout's own default, so unset behaves exactly as
+          # before for every existing caller.
+          ref: ${{ inputs.ref }}
 
       - name: Validate inputs and setup Dockerfile
         shell: bash


### PR DESCRIPTION
Closes the blocker described in [kairos-io/kairos#4307](https://github.com/kairos-io/kairos/issues/4307).

## Why

`reusable-factory.yaml` checks out with no `ref`, so it always builds whatever ref triggered the *calling* workflow:

```yaml
      - name: Checkout source
        uses: actions/checkout@9c091bb2… # v7
        with:
          fetch-depth: '0'
```

That is correct for every caller today. It makes one thing impossible: a `pull_request_target` workflow cannot build the pull request it is running for, because that event's context is the **base branch**.

That matters because `pull_request_target` is the only way to give a fork PR access to secrets — GitHub withholds them from `pull_request` runs originating in a fork, which is why every external contribution to `kairos-io/kairos` currently fails its image jobs with `Username and password required`.

Without a `ref`, such a caller would build the base branch, pass, and report **green on a pull request whose code was never compiled**. That is worse than the red X it replaces: a red check tells you nothing was verified, a wrong green actively misleads.

## What this does

Adds an optional `ref`, passed through to the checkout step. Default is `''`, which is `actions/checkout`'s own default — **every existing caller behaves exactly as before**.

## Two deliberate constraints

**`ref` only, not `repository`.** A pull request's head commit is reachable from the base repository via `refs/pull/<n>/head`, so no second repository ever needs naming. Leaving `repository` out means this input cannot be aimed at code outside the calling repo.

**The input is neutral; the caller carries the risk.** Passing an untrusted ref from a workflow that can also see secrets means running that code with those secrets. That is stated in the input's own documentation so it is visible at the point of use, and the motivating caller in `kairos-io/kairos` is being reviewed separately rather than smuggled in with this.

## Blast radius

`reusable-factory.yaml` is referenced by **7 workflows in `kairos-io/kairos` and by no other repository in the org**. The change is purely additive.

## Testing

Not run in CI — this workflow is only exercised by its callers, and a fork of it cannot be referenced by them. What I did verify: the file parses as valid YAML with the new input registered under `workflow_call.inputs` and its default resolving to the empty string, so the checkout step receives exactly what it receives today when the input is unset.

---

<sub>🤖 Prepared by `mauro-agent`, an AI agent operated by @mauromorales, with his review.</sub>
