### PR TITLE
feat: make the SBOM attestation optional

### DIFF
--- a/.github/workflows/reusable-factory.yaml
+++ b/.github/workflows/reusable-factory.yaml
@@ -131,6 +131,34 @@ on:
         type: boolean
         default: false
 
+      sbom:
+        type: boolean
+        default: true
+        description: |
+          Attach an SBOM attestation to the pushed image. Default true, so every
+          existing caller keeps its current behaviour.
+
+          Set false only when the attestation cannot be attached at all. BuildKit
+          refuses a single attestation larger than 41943040 bytes (40 MiB) and
+          fails the whole push, so an image whose SBOM crosses that line cannot
+          be published while this is true. The image itself is fine in that case:
+          the layers, manifest and config all export successfully and only the
+          attestation step fails.
+
+          The images that hit this are the ones with very large file counts --
+          the NVIDIA Jetson images, whose CUDA userspace produces an SPDX
+          document past the limit. Package versions are not the cause and
+          bumping them does not help, because the document scales with how many
+          packages and files an image contains, not with how old they are.
+
+          Turning this off is a real loss: consumers of that image get no
+          attached bill of materials. Prefer these first, and use this input when
+          neither is available:
+            1. Shrink the document -- package-level SPDX without file-level
+               entries is typically far under the limit.
+            2. Publish the SBOM as a separate artifact rather than an inline
+               attestation, which the 40 MiB cap does not apply to.
+
       # SARIF generation and upload toggles
       grype_sarif:
         type: boolean
@@ -863,7 +891,10 @@ jobs:
           sarif_file: 'grype.sarif'
           category: ${{ steps.setup.outputs.flavor }}-${{ steps.setup.outputs.flavor_release }}-${{ steps.setup.outputs.variant }}-${{ inputs.arch }}-${{ inputs.model }}${{ inputs.trusted_boot && '-uki' || '' }}
 
-      - name: Push Kairos image (build and push with SBOM)
+      # The step name no longer promises an SBOM, because `sbom` is now an
+      # input. A step called "with SBOM" that pushed without one would be the
+      # kind of small lie that costs someone an afternoon.
+      - name: Push Kairos image
         if: inputs.registry_domain != ''
         uses: docker/build-push-action@v7
         with:
@@ -871,7 +902,7 @@ jobs:
           file: ${{ env.DOCKERFILE_PATH }}
           platforms: linux/${{ inputs.arch }}
           push: true
-          sbom: true
+          sbom: ${{ inputs.sbom }}
           tags: ${{ steps.setup.outputs.image_tag }}
           labels: ${{ inputs.image_labels }}
           build-args: |


### PR DESCRIPTION
## The problem

BuildKit refuses a single attestation larger than **41943040 bytes — exactly 40 MiB** — and fails the whole push when one crosses it. This workflow hardcoded `sbom: true`, so a caller whose SBOM grew past that line had no way to publish the image at all.

The NVIDIA Jetson images hit it. From a recent `kairos` master run:

```
#12 [linux/arm64] generating sbom ...            DONE 12.3s
#13 exporting to image
#13   exporting layers                           done
#13   exporting manifest sha256:e63258b7...      done
#13   exporting config   sha256:982f44e9...      done
#13 ERROR: sbom.spdx.json exceeds 41943040 bytes
```

**The image is fine.** Layers, manifest and config all export successfully. Only the attestation step fails, and it takes the push down with it.

## Why the obvious fix does not work

Bumping package versions does not help. The document scales with **how many** packages and files an image contains, not with how old they are — and a newer package set is usually larger, so bumping pushes it further over. The Jetson images carry the CUDA userspace, which is why they cross the line and `rpi4` and `generic` do not.

## The change

One new input, `sbom`, defaulting to `true`. **Every existing caller keeps its current behaviour** and nothing changes without an explicit opt-out.

The push step is also renamed. It said "build and push with SBOM", which becomes untrue the moment a caller sets this false — the kind of small lie that costs someone an afternoon.

## Alternatives, which are better and are documented in the input itself

Turning off the attestation is a real loss: consumers of that image get no attached bill of materials. So the input description names the two better options and says to reach for this one last:

1. **Shrink the document.** Package-level SPDX without file-level entries is typically far under the limit, and keeps a usable SBOM.
2. **Publish the SBOM as a separate artifact** rather than an inline attestation. The 40 MiB cap does not apply.

Both need more work than this input does, and both are worth doing. This unblocks publishing the affected images in the meantime.

## Verification

The workflow file parses, and the new input is present with `default: true` alongside the other 46 inputs. Not exercised in CI here — the calling change in `kairos-io/kairos` is a separate PR, deliberately not stacked on this one.
